### PR TITLE
Update example for 50A with all sensors as of Aug 13th

### DIFF
--- a/hughes_esphome.yaml
+++ b/hughes_esphome.yaml
@@ -43,6 +43,11 @@ esp32_ble_tracker:
 ble_client:
   - mac_address: 0C:61:CF:32:4B:81
     id: power_watchdog
+    
+switch:
+  - platform: ble_client
+    ble_client_id: power_watchdog
+    name: "Watchdog Monitoring"
 
 sensor:
   - platform: hughes_power_watchdog
@@ -59,5 +64,12 @@ sensor:
       name: "Watchdog Current Line 2"
     power_line_2:
       name: "Watchdog Power Line 2"
+    combined_power:
+      name: "Watchdog Power"
     total_power:
       name: "Watchdog Cumulative Power Usage"
+    error_code_value:
+      name: "Watchdog Error Code"
+    error_code_text:
+      name: "Watchdog Error Text"
+   


### PR DESCRIPTION
Add combined_power for total wattage being used (L1 + L2)
add error_code_value for error code reporting
add error_code_text for a full text string of the error
add switch to turn off the ble connection so that a user could use phone app or something else to connect to watchdog.